### PR TITLE
Improve env config guidance and error messaging

### DIFF
--- a/spotter-free/.env.example
+++ b/spotter-free/.env.example
@@ -1,0 +1,3 @@
+# Example environment variables for Spotter Free
+# Copy this file to .env.local and fill in the values.
+APIFY_API_TOKEN=

--- a/spotter-free/.gitignore
+++ b/spotter-free/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/spotter-free/README.md
+++ b/spotter-free/README.md
@@ -41,13 +41,19 @@ cd spotter-fresh
 ```bash
 npm install
 ```
+3. Copy the example environment file:
+```bash
+cp .env.example .env.local
+```
 
-3. Run the development server:
+   Set any required values in `.env.local` (see file for details).
+
+4. Run the development server:
 ```bash
 npm run dev
 ```
 
-4. Open [http://localhost:3000](http://localhost:3000) in your browser
+5. Open [http://localhost:3000](http://localhost:3000) in your browser
 
 ### Available Scripts
 

--- a/spotter-free/src/app/api/instagram-fetch/route.ts
+++ b/spotter-free/src/app/api/instagram-fetch/route.ts
@@ -45,7 +45,10 @@ export async function POST(request: NextRequest) {
     if (!apifyApiToken) {
       console.error('APIFY_API_TOKEN is not configured')
       return NextResponse.json(
-        { error: 'API configuration error' },
+        {
+          error:
+            'Missing APIFY_API_TOKEN environment variable. See .env.example for setup.',
+        },
         { status: 500 }
       )
     }


### PR DESCRIPTION
## Summary
- clarify missing APIFY token error in instagram-fetch API route
- add example env file and document setup
- allow committing `.env.example`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c184706b508321b93fe77b1858b938